### PR TITLE
Adding documentation for seeing full list of options

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -27,3 +27,7 @@ From the root folder of your project. This assumes step definitions are in PROJE
 Or, set the the directory parameters manually
   stepdown --steps <step definition directory> --features <feature file directory>
   e.g. stepdown --steps features/step_definitions --features features
+
+== Options
+For a full list of available options
+  stepdown --help


### PR DESCRIPTION
I spent some time looking at the source trying to figure out what other available reporters there were only to find that `stepdown --help` displays this.

It wasn't obvious from the README that I could do this so I just added it.